### PR TITLE
Getting HTTP::Request::Params to install with the updated Email::MIME module

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+2015-08-11    1.02
+
+  - Update to clear an upstream bug created by changes to Email::MIME
+
 2004-05-11    1.01
 
   - Initial revision.

--- a/META.yml
+++ b/META.yml
@@ -1,7 +1,7 @@
 # http://module-build.sourceforge.net/META-spec.html
 #XXXXXXX This is a prototype!!!  It will change in the future!!! XXXXX#
 name:         HTTP-Request-Params
-version:      1.01
+version:      1.02
 version_from: lib/HTTP/Request/Params.pm
 installdirs:  site
 requires:

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,14 +1,14 @@
 use ExtUtils::MakeMaker;
 
 WriteMakefile (
-               AUTHOR        => 'Casey West <casey@geeknest.com>',
+               AUTHOR        => ['Casey West <casey@geeknest.com>', 'Ian Stuart <Ian.Stuart@ed.ac.uk>'],
                ABSTRACT      => "Retrieve GET/POST Parameters from HTTP Requests",
                NAME          => 'HTTP::Request::Params',
                PREREQ_PM     => {
                                  'CGI' => '3.00',
                                  'Class::Accessor::Fast' => '0.19',
                                  'Email::MIME::ContentType' => '1.0',
-                                 'Email::MIME::Modifier' => '1.42',
+                                 'Email::MIME' => '1.42',
                                  'HTTP::Request' => '1.40',
                                  'HTTP::Request::Common' => '1.26',
                                 },

--- a/README
+++ b/README
@@ -20,7 +20,7 @@ DESCRIPTION
                    });
 
     "req" - This required argument is either an "HTTP::Request" object or a
-    string containing an entier HTTP Request.
+    string containing an entire HTTP Request.
 
     Incoming query parameters come from two places. The first place is the
     "query" portion of the URL. Second is the content portion of an HTTP

--- a/lib/HTTP/Request/Params.pm
+++ b/lib/HTTP/Request/Params.pm
@@ -1,6 +1,6 @@
 package HTTP::Request::Params;
 
-# $Id: Params.pm,v 1.1 2005/01/12 16:42:32 cwest Exp $
+# $Id: Params.pm,v 1.2 2015/08/11 10:01:12 kiz Exp $
 use strict;
 
 =pod
@@ -30,7 +30,7 @@ use Email::MIME::Modifier;
 use Email::MIME::ContentType qw[parse_content_type];
 use HTTP::Request;
 use HTTP::Message;
-use base qw[Class::Accessor::Fast];
+use parent qw[Class::Accessor::Fast];
 
 =pod
 
@@ -85,7 +85,7 @@ sub new {
   my ($class) = shift;
   my $self = $class->SUPER::new(@_);
 
-  unless ( ref( $self->req ) ) {
+  if ( not ref( $self->req ) ) {
     $self->req( HTTP::Request->parse( $self->req ) );
   }
 
@@ -118,17 +118,19 @@ sub _find_params {
       $self->_add_to_field( $post_params, $name, $content );
     } ## end foreach my $part ( $self->mime...)
   } else {
-    my $body = $self->mime->bodyl chomp $body;
+    my $body = $self->mime->body;
+    chomp $body;
     $post_params = CGI->new($body)->Vars;
   }
 
   my $params = {};
 
+  # I dislike the use of $_
   for my $k ( keys %{$post_params} ) {
-    $self->_add_to_field( $params, $_, $post_params->{$k} );
+    $self->_add_to_field( $params, $k, $post_params->{$k} );
   }
   for my $k ( keys %{$query_params} ) {
-    $self->_add_to_field( $params, $_, $query_params->{$_} );
+    $self->_add_to_field( $params, $k, $query_params->{$k} );
   }
   $self->params($params);
 
@@ -180,7 +182,7 @@ Ian Stuart, <F<Ian.Stuart@ed.ac.uk>>.
 
 =head1 COPYRIGHT
 
-  Copyright (c) 2005 Casey West.  All rights reserved.
+  Copyright (c) 2015 Casey West.  All rights reserved.
   This module is free software; you can redistribute it and/or modify it
   under the same terms as Perl itself.
 

--- a/t/test.t
+++ b/t/test.t
@@ -1,9 +1,16 @@
-#!/usr/local/bin/perl
+#!/usr/bin/perl
 use Test::More qw[no_plan];
 use strict;
 $^W = 1;
 
 BEGIN {
+    require_ok 'CGI';
+    require_ok 'Email::MIME';
+    require_ok 'Email::MIME::Modifier';
+    require_ok 'Email::MIME::ContentType';
+    require_ok 'HTTP::Request';
+    require_ok 'HTTP::Message';
+    require_ok 'Class::Accessor::Fast';
     use_ok 'HTTP::Request::Params';
     use_ok 'HTTP::Request::Common';
     use_ok 'HTTP::Request';


### PR DESCRIPTION
See bug https://rt.cpan.org/Public/Bug/Display.html?id=86635

(I'm also happy to adopt this package in CPAN)
